### PR TITLE
Param Types

### DIFF
--- a/figgy.go
+++ b/figgy.go
@@ -87,6 +87,9 @@ func newField(key string, decrypt bool) *field {
 	}
 }
 
+type P Params
+type Params map[string]interface{}
+
 // Load AWS Parameter Store parameters based on the defined tags.
 //
 // When a source type is an array, it is assumed the parameter being loaded

--- a/figgy.go
+++ b/figgy.go
@@ -87,8 +87,8 @@ func newField(key string, decrypt bool) *field {
 	}
 }
 
-type P Params
-type Params map[string]interface{}
+// P is a convenience alias for passing paramters to LoadWithParameters
+type P map[string]interface{}
 
 // Load AWS Parameter Store parameters based on the defined tags.
 //

--- a/figgy_test.go
+++ b/figgy_test.go
@@ -560,9 +560,9 @@ func TestTagParse(t *testing.T) {
 			Field string `ssm:"-"`
 		}{}, want: nil, err: nil},
 		"with parameter": {in: struct {
-			Fields string `ssm:"/{{.Env}}/environment"`
+			Fields string `ssm:"/{{.env}}/environment"`
 		}{}, want: &field{key: "/dev/environment"},
-			data: struct{ Env string }{"dev"}},
+			data: P{"env": "dev"}},
 		"with json": {in: struct {
 			Field string `ssm:"simplejson,json"`
 		}{}, want: &field{key: "simplejson", json: true}, err: nil},


### PR DESCRIPTION
What do you think of adding the following types as an alternative to defining one off types for parameter passing?

```Go
// figgy.P or figgy.Params
figgy.LoadWithParameters(client, &config, figgy.P{"env": "prod"})
figgy.LoadWithParameters(client, &config, figgy.Params{"env": "prod"})

// one off struct
figgy.LoadWithParameters(client, &config, struct Params{ Env string}{"prod"})

// map[string]interface{}
figgy.LoadWithParameters(client, &config, map[string]interface{}{"env": "prod"})
```
